### PR TITLE
build out internal whitelist api rather than non-restful solution

### DIFF
--- a/app/controllers/api/internal/whitelists_controller.rb
+++ b/app/controllers/api/internal/whitelists_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module Internal
+    class WhitelistsController < ActionController::API
+      # Returns a jbuilder template
+      # Formatted with the user's AthensMC username and minecraft UUID
+      def show
+        @users = User.joins(:whitelist_request).where(
+          'whitelist_requests.status IN (?)', 'approved'
+        ).references(:whitelist_request)
+      end
+    end
+  end
+end

--- a/app/views/api/internal/whitelists/show.json.jbuilder
+++ b/app/views/api/internal/whitelists/show.json.jbuilder
@@ -1,0 +1,6 @@
+## Generates a JSON object for each user with their dashed_uuid as a uuid: object
+## Also includes their AthensMC username as name: though Minecraft may ignore/replace that
+json.array! @users do |users|
+  json.uuid users.dashed_uuid
+  json.name users.username
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,16 @@ Rails.application.routes.draw do
   get 'links/minecraft' => 'links#minecraft'
   post 'links' => 'links#create'
 
+  # API Endpoints
+  namespace :api do
+    # Internal Endpoints are not given to any external users, and are subject
+    # to change at any time without prior notice.
+    # These are commonly used in scripts for automation.
+    namespace :internal do
+      resource :whitelist, only: %w(show)
+    end
+  end
+
   resources :whitelist_requests, path: 'join'
   resources :revisions
   resources :casts

--- a/test/controllers/api/internal/whitelists_controller_test.rb
+++ b/test/controllers/api/internal/whitelists_controller_test.rb
@@ -1,0 +1,21 @@
+require('test_helper')
+
+module Api
+  module Internal
+    class WhitelistsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @user = users(:one)
+        @user.update_columns(minecraft_uuid: '991ef20946474fe1900648f31e9697e7')
+      end
+
+      test 'get show' do
+        get api_internal_whitelist_url(format: :json)
+        response_body = JSON.parse(response.body)
+        assert_equal 1, response_body.size
+        assert_equal 2, response_body.first.keys.size
+        assert response_body.first.keys.include?("name")
+        assert response_body.first.keys.include?("uuid")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Builds out an api/internal/whitelist.json endpoint to retrieve the whitelist rather than our non-restful solution. 